### PR TITLE
fixed request_writer.py to properly pull headers. looks like the api for

### DIFF
--- a/minigun_recorder.sh
+++ b/minigun_recorder.sh
@@ -17,6 +17,6 @@ if [ ! -e recording.json ]; then
 fi
 
 echo "***** Processing captured requests"
-node process.js recording.json > minigun_recorded_script.json
+nohup node process.js recording.json > minigun_recorded_script.json
 rm recording.json
 echo "***** Minigun script created in recorded_script.json"

--- a/request_writer.py
+++ b/request_writer.py
@@ -27,7 +27,7 @@ def response(context, flow):
     #
     headers = []
 
-    for h in flow.request.headers:
+    for h in flow.request.headers.fields:
       if not(h[0].lower() in exclude_headers):
         headers.append([h[0].lower(), h[1]])
 


### PR DESCRIPTION
getting the headers changed a bit.

added "nohup" to minigun_recorder.sh to properly pipe output of node on
cygwin boxes. don't know if this works on all platforms. not even sure if this is even useful, as this script for me just quits when I break. I'm probably not using it right.
